### PR TITLE
Revert "chore(deps): update helm release cert-manager to v1.7.1"

### DIFF
--- a/cluster/core/cert-manager/helm-release.yaml
+++ b/cluster/core/cert-manager/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.jetstack.io/
       chart: cert-manager
-      version: v1.7.1
+      version: v1.6.1
       sourceRef:
         kind: HelmRepository
         name: jetstack-charts

--- a/cluster/crds/cert-manager/kustomization.yaml
+++ b/cluster/crds/cert-manager/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # renovate: registryUrl=https://charts.jetstack.io chart=cert-manager
-  - https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.crds.yaml


### PR DESCRIPTION
Reverts parsec/home-cluster#6

CRDs will not import due to API error